### PR TITLE
F01, F02, F03, F04 now uses the same post-always clause as N01-N03

### DIFF
--- a/release_testing/functional_tests/F01.jenkinsfile
+++ b/release_testing/functional_tests/F01.jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
 
                     sh 'mv scripts/analytics/rmd/f1.html scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
                         
-                    archiveArtifacts artifacts: 'scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
+                    archiveArtifacts artifacts: "scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html"
 	        }
 	    }
 	}

--- a/release_testing/functional_tests/F02.jenkinsfile
+++ b/release_testing/functional_tests/F02.jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
 
                     sh 'mv scripts/analytics/rmd/f1.html scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
 
-                    archiveArtifacts artifacts: 'scripts/analytics/rmd/${BUILD_NUMBER}_${JOBASE_NAME}.html'
+                    archiveArtifacts artifacts: "scripts/analytics/rmd/${BUILD_NUMBER}_${JOBASE_NAME}.html"
 	        }
 	    }
         }

--- a/release_testing/functional_tests/F03.jenkinsfile
+++ b/release_testing/functional_tests/F03.jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
 
                     sh 'mv scripts/analytics/rmd/f1.html scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
 
-                    archiveArtifacts artifacts: 'scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
+                    archiveArtifacts artifacts: "scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html"
 	        }
 	    }
         }

--- a/release_testing/functional_tests/F04.jenkinsfile
+++ b/release_testing/functional_tests/F04.jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
 
                     sh 'mv scripts/analytics/rmd/f1.html scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
 
-                    archiveArtifacts artifacts: 'scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html'
+                    archiveArtifacts artifacts: "scripts/analytics/rmd/${BUILD_NUMBER}_${JOB_BASE_NAME}.html"
 	        }
 	    }
         }


### PR DESCRIPTION
Currently F01-F04 still uses outdated stage-clause/completely omit the report generation.
They are updated so that the report-generation is done as post-always as found in the tested N01-N03.