### PR TITLE
F07 extension

### DIFF
--- a/release_testing/functional_tests/F07.jenkinsfile
+++ b/release_testing/functional_tests/F07.jenkinsfile
@@ -10,6 +10,23 @@ pipeline {
 
     environment {
         PATH = '/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin'
+        BLACKLIST = '''/var/data/Aida/eth-tests/GeneralStateTests/stCodeCopyTest/ExtCodeCopyTests.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stCreate2/CreateMessageRevertedOOGInInit.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stEIP158Specific/EXTCODESIZE_toEpmty.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stEIP158Specific/vitalikTransactionTest.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stNonZeroCallsTest/NonZeroValue_SUICIDE_ToOneStorageKey.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stRevertTest/RevertPrecompiledTouchExactOOG.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stSpecialTest/eoaEmpty.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial00_2.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial00.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial10_2.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial10.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial20_2.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stTimeConsuming/sstore_combinations_initial20.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stZeroKnowledge2/ecadd_0-0_0-0_21000_80.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stZeroKnowledge2/ecadd_1-3_0-0_25000_80.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stZeroKnowledge2/ecmul_0-3_5616_28000_96.json,\
+            /var/data/Aida/eth-tests/GeneralStateTests/stZeroKnowledge/ecmul_1-3_0_28000_80.json'''
     }
 
     parameters {
@@ -61,10 +78,13 @@ pipeline {
                 sh "rm -f *.cpuprofile *.memprofile *.log"
 
                 script {
-                    def  FILES_LIST = sh (script: "find /var/data/Aida/eth-tests/ -type f", returnStdout: true).trim()
+                    def FILES_LIST = sh (script: "find /var/data/Aida/eth-tests/ -type f", returnStdout: true).trim()
+                    def BLACKLIST_ARRAY = BLACKLIST.tokenize(",").collect { it.trim() }
 
                     for(String file : FILES_LIST.split("\\r?\\n")){
-                        sh """build/aida-vm-sdb ethereum-test --continue-on-failure \
+                        if (BLACKLIST_ARRAY.contains(file)) continue
+
+                        sh """build/aida-vm-sdb ethereum-test --validate-state-hash --continue-on-failure \
                                         --db-impl carmen --db-variant go-file --carmen-schema 5 \
                                         --db-tmp /var/data/Aida/statedb \
                                         --shadow-db --db-shadow-impl geth \


### PR DESCRIPTION
Reintroduces carmen and tosca version management
Extends the set of ethereum tests to run. This includes a primitive blacklist of reported failing tests.