### PR TITLE
RPC dataset upload and download pipelines

### DIFF
--- a/utils/file-downloader.jenkinsfile
+++ b/utils/file-downloader.jenkinsfile
@@ -1,0 +1,72 @@
+pipeline {
+        agent { node "${NodeLabel}" }
+
+        environment {
+        PATH = '/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin'
+        url = "https://aida.archive.fantom.network/"
+    }
+
+    parameters {
+        string(defaultValue: "", description: '', name: 'NodeLabel')
+        string(defaultValue: "transfer.txt", description: '', name: 'FileName')
+        string(defaultValue: "/var/src/Aida/rpc-recordings", description: '', name: 'DestinationPath')
+    }
+    stages {
+        stage('Download') {
+            steps {
+                script {
+                    if ("${NodeLabel}" == "") {
+                        currentBuild.result = 'FAILURE'
+                        error("Error NodeLabel wasn't correctly supplied")
+                    }
+
+                    def outputFile = "${DestinationPath}/${FileName}"
+                    def skipExecution = false
+                    // CHECK EXISTANCE
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
+                        // wrapped in catchError because find gives error if not found
+                        // || true is necessary so the stage is not marked as failure
+                        def fileExistance = sh(script: "find ${outputFile} || true", returnStdout: true);
+                        if (fileExistance.trim() == outputFile.trim()) {
+                            sh "echo skip - file exists"
+                            skipExecution = true
+                        }
+                    }
+
+                    // return from skip must be done outside of catchError scope
+                    if (skipExecution) {
+                        return
+                    }
+
+                    // CREATE DIRECTORY
+                    sh "mkdir -p ${DestinationPath}"
+
+                    // DOWNLOAD FILE
+                    sh "wget ${url}${FileName} -O ${outputFile}"
+
+                    // DOWNLOAD MD5
+                    md5url = "${url}${FileName}.md5"
+                    sh "echo ${md5url}"
+
+                    def md5Expected = sh(script: "curl ${md5url}", returnStdout: true);
+
+
+                    // CALCULATE MD5
+                    def fileNameMd5 = sh(script: "md5sum ${outputFile}", returnStdout: true);
+                    int indexOfSpace = fileNameMd5.lastIndexOf(' ');
+                    String md5Calculated = fileNameMd5.substring(0, indexOfSpace);
+
+                    // COMPARE MD5
+                    if (md5Expected.trim() != md5Calculated.trim()) {
+                        sh "echo removing corrupted file ${outputFile}"
+                        sh "rm ${outputFile}"
+                        currentBuild.result = 'FAILURE'
+                        error("Error hash missmatch: got ${md5Calculated}, expected got ${md5Expected}")
+                    } else {
+                        sh "echo hash ${md5Calculated} confirmed"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/utils/file-downloader.jenkinsfile
+++ b/utils/file-downloader.jenkinsfile
@@ -7,9 +7,9 @@ pipeline {
     }
 
     parameters {
-        string(defaultValue: "", description: '', name: 'NodeLabel')
-        string(defaultValue: "transfer.txt", description: '', name: 'FileName')
-        string(defaultValue: "/var/src/Aida/rpc-recordings", description: '', name: 'DestinationPath')
+        string(defaultValue: "", description: 'A target node', name: 'NodeLabel')
+        string(defaultValue: "transfer.txt", description: 'A file to be downloaded', name: 'FileName')
+        string(defaultValue: "/var/src/Aida/some-path", description: 'The destination path must be under /var/src or /var/data', name: 'DestinationPath')
     }
     stages {
         stage('Download') {

--- a/utils/file-uploader.jenkinsfile
+++ b/utils/file-uploader.jenkinsfile
@@ -1,0 +1,46 @@
+pipeline {
+    agent { node 'xapi240' }
+
+    environment {
+        PATH = '/usr/local/bin:/usr/bin:/bin:/usr/local/go/bin'
+        DestinationPath = "/var/opera/Aida/mainnet-data/archive"
+    }
+    
+    parameters {
+        string(defaultValue: "xapi215", description: '', name: 'SourceNode')
+        string(defaultValue: "/var/opera/Aida/mainnet-data/transfer.txt", description: '', name: 'SourcePath')
+    }
+    
+    stages {
+        stage('Transfer') {
+            steps {
+                script {
+
+                    HashMap<String, String> serverIpMap = new HashMap<>();
+                    serverIpMap.put("xapi210", "5.9.107.121");
+                    serverIpMap.put("xapi215", "142.132.147.172");
+                    serverIpMap.put("xapi282", "135.181.161.97");
+                    serverIpMap.put("xapi310", "138.201.126.93");
+                    //TODO Map of all servers either:
+                    // config on 240
+                    // or list here
+                    // or retrieve from jenkins (stores nodes and ip addresses)
+                    
+                    String ipAddress = serverIpMap.get(SourceNode);
+                    
+                    String FileName = SourcePath.substring(SourcePath.lastIndexOf("/") + 1);
+                    sh "echo ${FileName}"
+                    try {
+                        sh "rsync -e 'ssh -p 2201' --progress -c ${ipAddress}:${SourcePath} ${DestinationPath}/${FileName}"
+                    } catch (IOException e) {
+                        sh "rsync -e 'ssh -p 2201 -o StrictHostKeyChecking=no' --progress -c ${ipAddress}:${SourcePath} ${DestinationPath}/${FileName}"
+                    }
+                    def fileNameMd5 = sh(script: "md5sum ${DestinationPath}/${FileName}", returnStdout: true);
+                    int indexOfSpace = fileNameMd5.lastIndexOf(' ');
+                    String md5 = fileNameMd5.substring(0, indexOfSpace);
+                    sh "echo ${md5} | tee ${DestinationPath}/${FileName}.md5"
+                }   
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pipelines are set to upload to or download from webserver running on xapi240. They can be used for any files, but mainly for the rpc-recordings.