### PR TITLE
F05 now correctly uses aida-rpc.rmd

### DIFF
--- a/release_testing/functional_tests/F02-F05.jenkinsfile
+++ b/release_testing/functional_tests/F02-F05.jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                 sh """./scripts/analytics/rmd/gen_processing_reports.sh \
                     ./scripts/analytics/rmd/knit.R \
                     ${RegisterRunPath}/${RunId == '' ? BUILD_NUMBER+'_F05' : RunId}.db \
-                    ./scripts/analytics/rmd/f1.rmd \
+                    ./scripts/analytics/rmd/aida-rpc.rmd \
                     ./scripts/analytics/rmd"""
                 
                 sh "mv scripts/analytics/rmd/f1.html scripts/analytics/rmd/${BUILD_NUMBER}_F05.html"


### PR DESCRIPTION
Currently, In F02-F05 pipeline, F05 incorrectly uses substate script even though it is aida-rpc.
This PR corrects this error.
