### PR TITLE
toolbox pipeline extended of import and export of archive genesis

### DIFF
--- a/carmen/sync_toolchain.jenkinsfile
+++ b/carmen/sync_toolchain.jenkinsfile
@@ -141,19 +141,6 @@ pipeline {
                                 sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/a/state_db_carmen_go-file_${params.firstBlockHeight}-recov/archive"
                             }
                         }
-
-                        stage('Continue Synchronise Archive DB') {
-                            steps {
-                                sh "cp ${params.tmpDb}/a/state_db_carmen_go-file_${params.firstBlockHeight}/statedb_info.json ${params.tmpDb}/a/state_db_carmen_go-file_${params.firstBlockHeight}-recov/"
-                                script {nextBlock=params.firstBlockHeight.toInteger()+1}
-                                sh "build/aida-vm-sdb substate --aida-db ${params.aidaDb} --db-tmp ${params.tmpDb}/a --db-src ${params.tmpDb}/a/state_db_carmen_go-file_${params.firstBlockHeight}-recov/ --vm-impl=lfvm --db-impl carmen --db-variant go-file --carmen-schema 5 --archive --archive-variant s5 --keep-db --validate-state-hash ${nextBlock} ${params.secondBlockHeight}"
-                            }
-                        }    
-                        stage('Re-verify Archive DB') {
-                            steps {
-                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/a/state_db_carmen_go-file_${params.secondBlockHeight}/archive"
-                            }
-                        }                             
                     }
                     post {
                         always {


### PR DESCRIPTION
This PR
* extends the carmen toolbox pipeline of testing Import and Export of genesis file of Archive
* workflow is distinguishably split into Archive and LiveDB version, both doing the same steps
   * sync a few blocks
   * export genersis
   * import genesis
   * verify db
   * continue sync
* pipeline is organised into two parallel stages  