### PR TITLE
Add script to run Carmen stress tests

### DIFF
--- a/carmen/stress-test.jenkinsfile
+++ b/carmen/stress-test.jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent {label 'short'}
+    agent {label 'long'}
     
     options { timestamps () }
     


### PR DESCRIPTION
This PR adds a script to run long-running stress Carmen stress tests recently introduced into the Carmen project.

These tests take too much time to be executed as part of the regular CI. This script should provide the basis for running them as part of nightly builds on Jenkins.