### PR TITLE
extends carmen sync toolbox of import/export/sync/verification of archive

### DIFF
--- a/carmen/sync_toolchain.jenkinsfile
+++ b/carmen/sync_toolchain.jenkinsfile
@@ -148,7 +148,66 @@ pipeline {
                         }
                     }
                 }
-                   
+                stage('Archive And Live DB Toolchain') {
+                    agent {label 'short'}
+                    stages {
+                        stage('Build') {
+                            steps {
+                                deleteDir()
+                                unstash 'aida-carmen'
+                                sh "mkdir -p ${params.tmpDb}/al"
+                            }
+                        } 
+                        stage('Synchronise Archive DB') {
+                            steps {
+                                sh "build/aida-vm-sdb substate --aida-db  ${params.aidaDb} --db-tmp  ${params.tmpDb}/al  --vm-impl=lfvm --db-impl carmen --db-variant go-file --carmen-schema 5 --archive --archive-variant s5 --keep-db  --validate-state-hash 0 ${params.firstBlockHeight} "
+                            }
+                        }
+
+                        stage('Verify Archive DB') {
+                            steps {
+                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}/archive"
+                            }
+                        }
+
+                        stage('Export Archive DB') {
+                            steps {
+                                sh "cd carmen/go && go run ./state/mpt/tool export ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}/archive ${params.tmpDb}/al/genesis.dat"
+                            }
+                        }
+
+                        stage('Import Archive and Live DB') {
+                            steps {
+                                sh "cd carmen/go && go run ./state/mpt/tool import ${params.tmpDb}/al/genesis.dat ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}-recov"
+                            }
+                        }
+
+                        stage('Verify Recovered Archive and Live DB') {
+                            steps {
+                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}-recov/live"
+                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}-recov/archive"
+                            }
+                        }
+                        stage('Continue Synchronise Archive and Live DB') {
+                            steps {
+                                sh "cp ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}/statedb_info.json ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}-recov/"
+                                script {nextBlock=params.firstBlockHeight.toInteger()+1}
+                                sh "build/aida-vm-sdb substate --aida-db ${params.aidaDb} --db-tmp ${params.tmpDb}/al --db-src ${params.tmpDb}/al/state_db_carmen_go-file_${params.firstBlockHeight}-recov/ --vm-impl=lfvm --db-impl carmen --db-variant go-file --carmen-schema 5 --archive --archive-variant s5 --keep-db --validate-state-hash ${nextBlock} ${params.secondBlockHeight}"
+                            }
+                        }    
+                        stage('Re-verify Archive and Live DB') {
+                            steps {
+                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/al/state_db_carmen_go-file_${params.secondBlockHeight}/live"
+                                sh "cd carmen/go && go run ./state/mpt/tool verify ${params.tmpDb}/al/state_db_carmen_go-file_${params.secondBlockHeight}/archive"
+                            }
+                        }      
+                    }
+                    post {
+                        always {
+                            sh "rm -rf ${params.tmpDb}/al"
+                        }
+                    }
+                }                   
             }
         }         
     }


### PR DESCRIPTION
This PR extends the pipeline that verifies carmen toolchain of import, export, and verification of carmen database.

It shoes recovery of the database that includes both archive and live dbs, verification of both databases, and continued synchronisation. 

These steps are added as a third parallel branch of the existing pipeline, i.e. we now have:
* Toolchain for LiveDB
* Toolchain for ArchiveDB
*  (new) Toolchain for a database that contains both Archive and LiveDBs
