### PR TITLE
Add export/import genesis to P02

### DIFF
--- a/release_testing/operational_tests/P02.jenkinsfile
+++ b/release_testing/operational_tests/P02.jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
         stage('Export & import genesis') {
             steps {
                 sh "./build/sonictool --datadir ${DATADIRPATH} export genesis ${DATAROOTPATH}/sonic.g"
-                sh "./build/sonictool --datadir ${GENESISDBPATH} genesis ${DATAROOTPATH}/sonic.g"
+                sh "./build/sonictool --datadir ${GENESISDBPATH} genesis --experimental ${DATAROOTPATH}/sonic.g"
                 sh "./build/sonictool --datadir ${GENESISDBPATH} check live"
             }
         }


### PR DESCRIPTION
This PR updates stage to match Carmen tool-chain tests. It addsw stages which export and import genesis,  combines stages and adds DB verification each time a db is modified.
 
Resolves #55