### PR TITLE
Add P03 blockchain synchronize test

### DIFF
--- a/release_testing/operational_tests/P03.jenkinsfile
+++ b/release_testing/operational_tests/P03.jenkinsfile
@@ -1,7 +1,7 @@
 // P03 performs end-to-end test synchronizing from the first opera block to the current head
 
 pipeline {
-    agent {label 'functional'}
+    agent { node "${NodeLabel}" }
 
     options {
         timestamps ()
@@ -18,6 +18,7 @@ pipeline {
     }
 
     parameters {
+        string(defaultValue: "functional", description: 'Agent or agent\'s label where the job will run', name: 'NodeLabel')
         string(defaultValue: "develop", description: 'Can be either branch name or commit hash.', name: 'GoOperaNormaVersion')
     }
 


### PR DESCRIPTION
This test aims to perform end-to-end synchronization from a legacy genesis (4.5M) to the latest block on tha chain.

The test downloads a genesis if fine is not already exists, prepare statedb then start syncrhonizing the chian to the head block.

Resolves #73 