### PR TITLE
Add memory limit to tosca tests

### DIFF
--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -10,6 +10,8 @@ pipeline {
 
     environment {
         GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '30GiB'
     }
 
     parameters {

--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
     }
 
     environment {
-            GOROOT = '/usr/lib/go-1.21/'
+        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '60GiB'
     }
 
     parameters {

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
     }
 
     environment {
-            GOROOT = '/usr/lib/go-1.21/'
+        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '60GiB'
     }
 
     parameters {

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
     }
 
     environment {
-            GOROOT = '/usr/lib/go-1.21/'
+        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '60GiB'
     }
 
     parameters {

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -10,7 +10,9 @@ pipeline {
     }
 
     environment {
-            GOROOT = '/usr/lib/go-1.21/'
+        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '60GiB'
     }
 
     parameters {


### PR DESCRIPTION
Limit the memory usage of tosca tests to avoid unreachable agents.