### PR TITLE
Stop after first detected race condition

### DIFF
--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
         GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '30GiB'
+        GORACE = 'halt_on_error=1'
     }
 
     parameters {


### PR DESCRIPTION
Before this change, tests run with race detection enables would just log the error and keep running. If a detected race condition is common, this could result in huge logs. With this change, once an issue is detected, the process containing is halted.