### PR TITLE
Remove parallel sections in Tosca compliance tests pipeline.

### DIFF
--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     agent { label 'quick' }
 
     options {
-        timestamps ()
+        timestamps()
         timeout(time: 24, unit: 'HOURS') // expected ~30 minutes
         disableConcurrentBuilds(abortPrevious: false)
     }
@@ -16,7 +16,7 @@ pipeline {
     }
 
     parameters {
-        string(defaultValue: "main", description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
+        string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
     }
 
     stages {
@@ -32,58 +32,54 @@ pipeline {
                         url: 'https://github.com/Fantom-foundation/Tosca.git'
                     ]]
                 )
-                sh "git submodule update --init --recursive"
+                sh 'git submodule update --init --recursive'
 
-                sh "make -j"
+                sh 'make -j'
             }
         }
 
         stage('unit-tests') {
-	    parallel {
-	        stage('go-tests') {
-                    steps {
-                        sh "go test ./... -count 1"
-                    }
+            stage('go-tests') {
+                steps {
+                    sh 'go test ./... -count 1'
                 }
-                stage('go-tests-with-race-dedection') {
-                    steps {
-                        sh "go test -race ./... -count 1 -timeout 10000s"
-                    }
+            }
+            stage('go-tests-with-race-dedection') {
+                steps {
+                    sh 'go test -race ./... -count 1 -timeout 10000s'
                 }
-                stage('cpp-tests') {
-                    steps {
-                        sh "make test"
-                    }
+            }
+            stage('cpp-tests') {
+                steps {
+                    sh 'make test'
                 }
             }
         }
 
         stage('compliance-tests') {
-            parallel {
-                stage('geth') {
-                    steps {
-                        sh "go run ./go/ct/driver run geth"
-                    }
+            stage('geth') {
+                steps {
+                    sh 'go run ./go/ct/driver run geth'
                 }
-                stage('lfvm') {
-                    steps {
-                        sh "go run ./go/ct/driver run lfvm"
-                    }
+            }
+            stage('lfvm') {
+                steps {
+                    sh 'go run ./go/ct/driver run lfvm'
                 }
-                stage('evmzero') {
-                    steps {
-                        sh "go run ./go/ct/driver run evmzero"
-                    }
+            }
+            stage('evmzero') {
+                steps {
+                    sh 'go run ./go/ct/driver run evmzero'
                 }
-                stage('geth-with-race-detection') {
-                    steps {
-                        sh "go run -race ./go/ct/driver run geth"
-                    }
+            }
+            stage('geth-with-race-detection') {
+                steps {
+                    sh 'go run -race ./go/ct/driver run geth'
                 }
-                stage('lfvm-with-race-detection') {
-                    steps {
-                        sh "go run -race ./go/ct/driver run lfvm"
-                    }
+            }
+            stage('lfvm-with-race-detection') {
+                steps {
+                    sh 'go run -race ./go/ct/driver run lfvm'
                 }
             }
         }
@@ -96,7 +92,7 @@ pipeline {
                 string(name: 'name', value: "${currentBuild.fullDisplayName}"),
                 string(name: 'duration', value: "${currentBuild.duration}"),
                 string(name: 'url', value: "${currentBuild.absoluteUrl}"),
-                string(name: 'user', value: "tosca")
+                string(name: 'user', value: 'tosca')
             ]
         }
     }


### PR DESCRIPTION
Execution times are suspiciously long, and these parallel sections cover steps which are parallel themselves. 
Nested parallelism will significantly increase memory usage and force threads to compete for execution.

Please review commit [3efb247381cfa09e13e63c733196e833d147ae23](https://github.com/Fantom-foundation/LaScala/commit/3efb247381cfa09e13e63c733196e833d147ae23) first

Additionally, automatic formatting has been used for the file. This later change can be undone if unwanted. 
