### PR TITLE
Add Tosca fuzzing jenkinsfile

### DIFF
--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         choice(
             name: 'EntryPoint',
             choices: ['FuzzLfvm', 'FuzzGeth', 'FuzzDifferentialLfvmVsGeth'],
-            description: 'Selects which fuzzer test fucntion to start.')
+            description: 'Selects which fuzzer test function to start.')
     }
 
     stages {

--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -1,0 +1,74 @@
+// Runs Tosca Fuzzing Tests
+pipeline {
+    agent { label 'quick' }
+
+    options {
+        timestamps()
+        timeout(time: 2, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: false)
+    }
+
+    environment {
+        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '30GiB'
+        GORACE = 'halt_on_error=1'
+    }
+
+    parameters {
+        string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
+
+        choice(
+            name: 'EntryPoint',
+            choices: ['FuzzLfvm', 'FuzzGeth', 'FuzzDifferentialLfvmVsGeth'],
+            description: 'Selects which fuzzer test fucntion to start.')
+    }
+
+    stages {
+        stage('ceuild') {
+            steps {
+                script {
+                    currentBuild.description = "Building on ${env.NODE_NAME}"
+                }
+
+                checkout scmGit(
+                    branches: [[name: "$ToscaVersion"]],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/Fantom-foundation/Tosca.git'
+                    ]]
+                )
+                sh 'git submodule update --init --recursive'
+            }
+        }
+
+        stage('build-and-test') {
+            steps {
+                // compile go & c++ code
+                sh 'make'
+                // Unit tests are run to ensure that the code is working as expected
+                sh 'make test'
+            }
+        }
+
+        stage('fuzzing-test') {
+            steps {
+                sh "go test -fuzz=$EntryPoint ./go/ct"
+            }
+        }
+    }
+
+    post {
+        always {
+            // Archive the fuzzing test results for later inspection
+            archiveArtifacts artifacts: "go/ct/testdata/fuzz/$EntryPoint/*"
+            // Send a slack notification
+            build job: '/Notifications/slack-notification', parameters: [
+                string(name: 'result', value: "${currentBuild.result}"),
+                string(name: 'name', value: "${currentBuild.fullDisplayName}"),
+                string(name: 'duration', value: "${currentBuild.duration}"),
+                string(name: 'url', value: "${currentBuild.absoluteUrl}"),
+                string(name: 'user', value: 'tosca')
+            ]
+        }
+    }
+}

--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                         url: 'https://github.com/Fantom-foundation/Tosca.git'
                     ]]
                 )
-                sh 'git submodule update --init --recursive'
+                sh 'git submodule update --init --recursive --depth 1'
             }
         }
 

--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     }
 
     stages {
-        stage('ceuild') {
+        stage('checkout') {
             steps {
                 script {
                     currentBuild.description = "Building on ${env.NODE_NAME}"
@@ -43,9 +43,9 @@ pipeline {
 
         stage('build-and-test') {
             steps {
-                // compile go & c++ code
-                sh 'make'
-                // Unit tests are run to ensure that the code is working as expected
+                // Unit tests are run to ensure that the code is working as expected.
+                // make test will build first, this makefile will call make with parallel
+                // jobs inside.
                 sh 'make test'
             }
         }


### PR DESCRIPTION
This PR adds a job to execute fuzzing tests as a nightly job.

Fuzzing is a testing mechanism that executes the code with different inputs for the time allowed, it will never end on its own. 

**What does this introduce:**

A jenkins file that builds Tosca, runs unit tests, and starts fuzzing.
The parameter option EntryPoint allows running different tests, as it only makes sense to run one test at the time.

**What does not handle:**

- This does not enable a jenkins job that actually executes the script. An experimental configuration can be found [here](https://scala.fantom.network/job/Tosca/job/Experimental/job/Test-Fuzzer)

**Future work:**
- Go Fuzzing has a mechanism to avoid repeating older runs, to improve domain coverage. To use it, we should cache the folder $home/.cache/go-build between runs. Not sure how big can this data get. 
- I am not sure if 2 hours are enough, this is a more budget problem than technical. It would be beneficial to run this often.
