### PR TITLE
removes module updates from carmen pipelines as it is required to hav…

### DIFF
--- a/carmen/validate-state-toolchain-archive.jenkinsfile
+++ b/carmen/validate-state-toolchain-archive.jenkinsfile
@@ -38,8 +38,6 @@ pipeline {
                         userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Carmen.git']]
                     )
                 }
-
-                sh "git submodule update --recursive"
             }
         }
 

--- a/carmen/validate-state-toolchain-live+archive.jenkinsfile
+++ b/carmen/validate-state-toolchain-live+archive.jenkinsfile
@@ -38,8 +38,6 @@ pipeline {
                         userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Carmen.git']]
                     )
                 }
-
-                sh "git submodule update --recursive"
             }
         }
 

--- a/carmen/validate-state-toolchain-live.jenkinsfile
+++ b/carmen/validate-state-toolchain-live.jenkinsfile
@@ -38,8 +38,6 @@ pipeline {
                         userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Carmen.git']]
                     )
                 }
-
-                sh "git submodule update --recursive"
             }
         }
 


### PR DESCRIPTION
This PR removes git module updates from the pipelines, because it is intended to checkout exactly requested version (i.e. `main`) of carmen, and not to replace this version by the version defined in Aida. 

The idea is to test the most recent versions, not the version that are defined in Aida. 