### PR TITLE
Modify Compliance tests to avoid overnight timeouts.

### DIFF
--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -72,14 +72,21 @@ pipeline {
                     sh 'go run ./go/ct/driver run evmzero'
                 }
             }
+        }
+
+        // Race detection tests:
+        // Interpreter implementations shall be thread save: multiple instances must run in parallel without
+        // interference. Race detection increasses the runtime significantly. Therefore, the number of tests
+        // cases is reduced by filtering for a subset of rules.
+        stage('race-detection') {
             stage('geth-with-race-detection') {
                 steps {
-                    sh 'go run -race ./go/ct/driver run geth'
+                    sh 'go run -race ./go/ct/driver run -f push geth'
                 }
             }
             stage('lfvm-with-race-detection') {
                 steps {
-                    sh 'go run -race ./go/ct/driver run lfvm'
+                    sh 'go run -race ./go/ct/driver run -f push lfvm'
                 }
             }
         }


### PR DESCRIPTION
Current compliance tests scripts did test CT runs with `go -race` flag enabled. This flag would dramatically increase execution time. 

The test target is to validate thread-safety of the different interpreters implemented using go.
After discussion, the Tosca team came with the trade-off solution of making a partial CT execution with a subset of the rules, to stress the infrastructure in a more manageable execution time.
