### PR TITLE
Fix Carmen Race-Detection test

### DIFF
--- a/carmen/race-detection.jenkinsfile
+++ b/carmen/race-detection.jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent {label 'db-small-ssd'}
+    agent {label 'db-small-nvme'}
 
     options {
         timestamps ()


### PR DESCRIPTION
This PR changes worker in Carmens `race-detection` test from `db-small-ssd` to `db-small-nvme`.

This test started failing on out of memory issue. `nvme` worker has slightly higher memory than `ssd` and fixes this issue.

In future we should divide `db-small-ssd` worker into one with small memory and other with higher memory.
Issue: #134