### PR TITLE
increases timeout for fuzzing tests

### DIFF
--- a/carmen/fuzzing.jenkinsfile
+++ b/carmen/fuzzing.jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                 deleteDir()
                 unstash 'source'
                 sh 'make'
-                sh 'cd go && go test ./...'
+                sh 'cd go && go test ./... -timeout 60m'
             }
         }
 


### PR DESCRIPTION
this PR increases timeout for carmen tests to prevent timeout failures on jenkins