### PR TITLE
Update Aida CI test

### DIFF
--- a/aida/CI.jenkinsfile
+++ b/aida/CI.jenkinsfile
@@ -185,7 +185,7 @@ pipeline {
                             def options = ""
                             if (block == GENESISBLOCK) {
                                 // prepare stateDB from genesis
-                                echo "Prepare an additoinal option for using an existing stateDB"
+                                echo "Prepare an additional option for using an existing stateDB"
                                 options = "--db-src ${TMPDB}/state_db_carmen_go-file/"
                             }
                             sh """build/aida-vm-sdb substate \


### PR DESCRIPTION
This PR includes the following changes

- Fix incorrect data path caused by refactoring in Aida
- Change the default schema to schema 5
- Reduce run time by creating src db from genesis instead of priming at block beyond 70M