### PR TITLE
Add LFVM conversion fuzzer

### DIFF
--- a/tosca/fuzzing-lfvm-converter.jenkinsfile
+++ b/tosca/fuzzing-lfvm-converter.jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     options {
         timestamps()
         // This is a global timeout for the whole pipeline,
-        // it is a failsave to prevent the pipeline from running if missonfigured.
+        // it is a failsave to prevent the pipeline from running if misconfigured.
         // This timeout will set the pipeline to ABORTED when triggered
         timeout(time: 2, unit: 'HOURS')
         disableConcurrentBuilds(abortPrevious: false)

--- a/tosca/fuzzing-lfvm-converter.jenkinsfile
+++ b/tosca/fuzzing-lfvm-converter.jenkinsfile
@@ -1,0 +1,76 @@
+// Runs Tosca Fuzzing Tests
+pipeline {
+    agent { label 'quick' }
+
+    options {
+        timestamps()
+        // This is a global timeout for the whole pipeline,
+        // it is a failsave to prevent the pipeline from running if missonfigured.
+        // This timeout will set the pipeline to ABORTED when triggered
+        timeout(time: 2, unit: 'HOURS')
+        disableConcurrentBuilds(abortPrevious: false)
+    }
+
+    environment {
+        GOROOT = '/usr/lib/go-1.21/'
+    }
+
+    parameters {
+        string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
+    }
+
+    stages {
+        stage('checkout') {
+            steps {
+                script {
+                    currentBuild.description = "Building on ${env.NODE_NAME}"
+                }
+
+                checkout scmGit(
+                    branches: [[name: "$ToscaVersion"]],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/Fantom-foundation/Tosca.git'
+                    ]]
+                )
+                sh 'git submodule update --init --recursive --depth 1'
+            }
+        }
+
+        stage('build-and-test') {
+            steps {
+                // Unit tests are run to ensure that the code is working as expected.
+                sh 'make test'
+            }
+        }
+
+        stage('fuzzing-test') {
+            steps {
+                // Fuzzing test runs for the provided time duration.
+                // Note: Make sure that the pipeline timeout is large enough
+                // to accommodate the fuzzing test duration, otherwise test
+                // will be aborted and therefore marked as red.
+                sh 'go test ./go/interpreter/lfvm -run none -fuzz LfvmConverter --fuzztime 1h'
+            }
+
+            post {
+                failure {
+                    // Archive the faulty inputs found to be downloaded and analyzed.
+                    archiveArtifacts artifacts: "go/ct/testdata/fuzz/$EntryPoint/*"
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Send a slack notification
+            build job: '/Notifications/slack-notification', parameters: [
+                string(name: 'result', value: "${currentBuild.result}"),
+                string(name: 'name', value: "${currentBuild.fullDisplayName}"),
+                string(name: 'duration', value: "${currentBuild.duration}"),
+                string(name: 'url', value: "${currentBuild.absoluteUrl}"),
+                string(name: 'user', value: 'tosca')
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new nightly fuzzing test.

Because of the scope of this test, it is configured to use one hour of time. Last detected failures crashed after few seconds, therefore one hour seems reasonable to start testing. 

Test configuration can be found [here](https://scala.fantom.network/job/Tosca/job/Experimental/job/Test-Fuzzer/31/) (notice that it was manually stopped) 

