### PR TITLE
Tosca pipelines: add rustc to path.

### DIFF
--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         GOGC = '50'
         GOMEMLIMIT = '30GiB'
         GORACE = 'halt_on_error=1'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {

--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
         GOGC = '50'
         GOMEMLIMIT = '30GiB'
         GORACE = 'halt_on_error=1'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {

--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {


### PR DESCRIPTION
For the incoming rust EVM, Tosca make will depend on the rust tool chain.

GCP images include the rust tool chain, but unfortunately it is not in the user PATH. This change adds it manually in each pipeline where Tosca Makefile is invoked (maybe transitively via Aida Makefile) 

blocks https://github.com/Fantom-foundation/Tosca/pull/778