### PR TITLE
Fix selection of Tosca main branch for validation tests

### DIFF
--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -42,9 +42,8 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
+                    sh "git submodule update --recursive"
                 }
-
-                sh "git submodule update --recursive"
 
                 sh "go mod tidy"
                 sh "make aida-vm"

--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                    sh "git submodule update --recursive"
+                	sh "git submodule update --recursive"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                	sh "git submodule update --recursive"
+                	sh "git submodule update --recursive --depth 1"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -42,9 +42,8 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
+                    sh "git submodule update --recursive"
                 }
-
-                sh "git submodule update --recursive"
 
                 sh "go mod tidy"
                 sh "make aida-vm"

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                    sh "git submodule update --recursive"
+                	sh "git submodule update --recursive"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                	sh "git submodule update --recursive"
+                	sh "git submodule update --recursive --depth 1"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -42,9 +42,8 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
+                    sh "git submodule update --recursive"
                 }
-
-                sh "git submodule update --recursive"
 
                 sh "go mod tidy"
                 sh "make aida-vm"

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                    sh "git submodule update --recursive"
+                	sh "git submodule update --recursive"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                	sh "git submodule update --recursive"
+                	sh "git submodule update --recursive --depth 1"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -42,9 +42,8 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
+                    sh "git submodule update --recursive"
                 }
-
-                sh "git submodule update --recursive"
 
                 sh "go mod tidy"
                 sh "make aida-vm"

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                    sh "git submodule update --recursive"
+                	sh "git submodule update --recursive"
                 }
 
                 sh "go mod tidy"

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 		branches: [[name: "${ToscaVersion}"]],
                 		userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
                 	)
-                	sh "git submodule update --recursive"
+                	sh "git submodule update --recursive --depth 1"
                 }
 
                 sh "go mod tidy"


### PR DESCRIPTION
This PR fixes the fetching of the main branch version of Tosca in nightly integration tests.

Before this PR, the scripts did fetch the latest version of Tosca, but override it again with a sub-subsequent submodule update command:
![image](https://github.com/user-attachments/assets/c51dbba0-17ac-4ef7-b937-e680a000448a)

This is part of Tosca's [#692](https://github.com/Fantom-foundation/Tosca/issues/692)
 