### PR TITLE
Tosca: Add missing tools to path to fix build

### DIFF
--- a/tosca/fuzzing-lfvm-converter.jenkinsfile
+++ b/tosca/fuzzing-lfvm-converter.jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
 
     environment {
         GOROOT = '/usr/lib/go-1.21/'
+        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
     }
 
     parameters {


### PR DESCRIPTION
After the inclusion of rust tool chain in the path for all pipelines using Tosca, this script got merged without the fix. 
This PR adds the required amend to the PATH variable. 