### PR TITLE
Remove GOROOT env variable

### DIFF
--- a/aida/CI.jenkinsfile
+++ b/aida/CI.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
 

--- a/carmen/fuzzing.jenkinsfile
+++ b/carmen/fuzzing.jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '6GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/race-detection.jenkinsfile
+++ b/carmen/race-detection.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/stable.jenkinsfile
+++ b/carmen/stable.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '6GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/stress-test-tool.jenkinsfile
+++ b/carmen/stress-test-tool.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/carmen/stress-test.jenkinsfile
+++ b/carmen/stress-test.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/carmen/transient-storage.jenkinsfile
+++ b/carmen/transient-storage.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-cpp-file-s3.jenkinsfile
+++ b/carmen/validate-cpp-file-s3.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-db-reset.jenkinsfile
+++ b/carmen/validate-db-reset.jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-go-file-s3.jenkinsfile
+++ b/carmen/validate-go-file-s3.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-go-s4.jenkinsfile
+++ b/carmen/validate-go-s4.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-go-s5-archive.jenkinsfile
+++ b/carmen/validate-go-s5-archive.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-go-s5.jenkinsfile
+++ b/carmen/validate-go-s5.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         AIDADB = '/mnt/aida-db-central/aida-db'

--- a/carmen/validate-state-toolchain-archive.jenkinsfile
+++ b/carmen/validate-state-toolchain-archive.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/carmen/validate-state-toolchain-init-archive.jenkinsfile
+++ b/carmen/validate-state-toolchain-init-archive.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         TMP_DB = '/mnt/tmp-disk'

--- a/carmen/validate-state-toolchain-live+archive.jenkinsfile
+++ b/carmen/validate-state-toolchain-live+archive.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/carmen/validate-state-toolchain-live.jenkinsfile
+++ b/carmen/validate-state-toolchain-live.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/carmen/validate-witness-proof.jenkinsfile
+++ b/carmen/validate-witness-proof.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
 
     environment {
         GORACE = 'halt_on_error=1'
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/functional_tests/F01.jenkinsfile
+++ b/release_testing/functional_tests/F01.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/functional_tests/F02/F02.jenkinsfile
+++ b/release_testing/functional_tests/F02/F02.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         DATAROOTPATH="/mnt/tmp-disk"

--- a/release_testing/functional_tests/F03.jenkinsfile
+++ b/release_testing/functional_tests/F03.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/functional_tests/F04.jenkinsfile
+++ b/release_testing/functional_tests/F04.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/functional_tests/F05.jenkinsfile
+++ b/release_testing/functional_tests/F05.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         SONICSTATEDB = '/mnt/sonic-statedb/mainnet/carmen'

--- a/release_testing/functional_tests/F06.jenkinsfile
+++ b/release_testing/functional_tests/F06.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/functional_tests/F07.jenkinsfile
+++ b/release_testing/functional_tests/F07.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         BLACKLIST = '''/mnt/tmp-disk/eth-tests/GeneralStateTests/stCodeCopyTest/ExtCodeCopyTests.json,\

--- a/release_testing/nonfunctional_tests/N01.jenkinsfile
+++ b/release_testing/nonfunctional_tests/N01.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/nonfunctional_tests/N02-N04.jenkinsfile
+++ b/release_testing/nonfunctional_tests/N02-N04.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/nonfunctional_tests/N03.jenkinsfile
+++ b/release_testing/nonfunctional_tests/N03.jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
     }

--- a/release_testing/operational_tests/P01.jenkinsfile
+++ b/release_testing/operational_tests/P01.jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
     }

--- a/release_testing/operational_tests/P02.jenkinsfile
+++ b/release_testing/operational_tests/P02.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         DATAROOTPATH="/mnt/tmp-disk/tooltmp"

--- a/release_testing/operational_tests/P03.jenkinsfile
+++ b/release_testing/operational_tests/P03.jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         DATAROOTPATH="/mnt/tmp-disk/tooltmp"

--- a/release_testing/operational_tests/P04.jenkinsfile
+++ b/release_testing/operational_tests/P04.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
         SONICSTATEDB = '/mnt/sonic-statedb/mainnet'

--- a/tosca/compliance-tests.jenkinsfile
+++ b/tosca/compliance-tests.jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '30GiB'
         GORACE = 'halt_on_error=1'

--- a/tosca/fuzzing-tests.jenkinsfile
+++ b/tosca/fuzzing-tests.jenkinsfile
@@ -12,7 +12,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '30GiB'
         GORACE = 'halt_on_error=1'

--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc

--- a/tosca/validate-geth.jenkinsfile
+++ b/tosca/validate-geth.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc

--- a/tosca/validate-lfvm-si.jenkinsfile
+++ b/tosca/validate-lfvm-si.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
         GOGC = '50'
         GOMEMLIMIT = '60GiB'
         PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc

--- a/utils/template.jenkinsfile
+++ b/utils/template.jenkinsfile
@@ -14,7 +14,8 @@ pipeline {
     }
 
     environment {
-        GOROOT = '/usr/lib/go-1.21/'
+        GOGC = '50'
+        GOMEMLIMIT = '120GiB'
     }
 
     // Parameters for the pipeline


### PR DESCRIPTION
Have to be merged when image with go version 1.22.4 is used in VMs