### PR TITLE
Tosca: Remove unnecessary environment

### DIFF
--- a/tosca/fuzzing-lfvm-converter.jenkinsfile
+++ b/tosca/fuzzing-lfvm-converter.jenkinsfile
@@ -11,11 +11,6 @@ pipeline {
         disableConcurrentBuilds(abortPrevious: false)
     }
 
-    environment {
-        GOROOT = '/usr/lib/go-1.21/'
-        PATH = "${env.HOME}/.cargo/bin:${env.PATH}" //< rustc
-    }
-
     parameters {
         string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
     }


### PR DESCRIPTION
- GOROOT is no longer needed and may point to the wrong go version
- rust is now in path