### PR TITLE
Add geth Sonic tests

### DIFF
--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     environment {
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
-	    TMPDB = '/mnt/tmp-disk'
+        TMPDB = '/mnt/tmp-disk'
     }
 
      parameters {

--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps ()
-        timeout (time: 3, unit: 'HOURS') // ~3h
+        timeout (time: 4, unit: 'HOURS') // ~2.5h
         disableConcurrentBuilds(abortPrevious: false)
     }
 
@@ -68,22 +68,22 @@ pipeline {
         }
         stage('GethDB+GethVM') {
             steps {
-                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package"
             }
         }
         stage('Carmen+GethVM') {
             steps {
-                sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+                sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package"
             }
         }
         stage('GethDB+LFVM') {
             steps {
-                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package"
             }
         }
         stage('Carmen+LFVM') {
             steps {
-                 sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+                 sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package"
             }
         }
     }

--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
         stage('Build') {
             steps {
                 sh "go mod tidy"
-                sh "make -j aida-vm-sdb"
+                sh "make aida-vm-sdb"
             }
         }
         stage('GethDB+GethVM') {

--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps ()
-        timeout (time: 1, unit: 'HOURS') // ~ 40min
+        timeout (time: 3, unit: 'HOURS') // ~3h
         disableConcurrentBuilds(abortPrevious: false)
     }
 
@@ -15,9 +15,9 @@ pipeline {
     }
 
      parameters {
-        string(defaultValue: "main", description: 'Can be either branch name or commit hash.', name: 'AidaVersion')
-        string(defaultValue: "main", description: 'Can be either branch name or commit hash.', name: 'CarmenVersion')
-        string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
+        string(name: 'AidaVersion', defaultValue: "main", description: 'Can be either branch name or commit hash.')
+        string(name: 'CarmenVersion', defaultValue: "main", description: 'Can be either branch name or commit hash.')
+        string(name: 'ToscaVersion', defaultValue: 'main', description: 'Can be either branch name or commit hash.')
     }
 
 
@@ -51,8 +51,10 @@ pipeline {
                 }
 
                 dir('eth-test-package') {
-                    sh "rm -rf ${env.WORKSPACE}/eth-test-package/tests"
-                    sh "git clone https://github.com/ethereum/tests"
+                    checkout scmGit(
+                        branches: [[name: "develop"]],
+                        userRemoteConfigs: [[url: 'https://github.com/ethereum/tests.git']]
+                    )
                 }
             }
         }
@@ -64,29 +66,24 @@ pipeline {
                 sh "make -j aida-vm-sdb"
             }
         }
-
-        stage('Start parallel stage execution') {
-            parallel {
-                stage('GethDB+GethVM') {
-                    steps {
-                        sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl geth --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
-                    }
-                }
-                stage('CarmenDB+GethVM') {
-                    steps {
-                        sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl geth --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
-                    }
-                }
-                stage('GethDB+LFVM') {
-                    steps {
-                        sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl lfvm --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
-                    }
-                }
-                stage('CarmenDB+LFVM') {
-                    steps {
-                         sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl lfvm --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
-                    }
-                }
+        stage('GethDB+GethVM') {
+            steps {
+                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+            }
+        }
+        stage('Carmen+GethVM') {
+            steps {
+                sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl geth --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+            }
+        }
+        stage('GethDB+LFVM') {
+            steps {
+                sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
+            }
+        }
+        stage('Carmen+LFVM') {
+            steps {
+                 sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl lfvm --db-tmp ${TMPDB} ${env.WORKSPACE}/eth-test-package/tests"
             }
         }
     }

--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -1,0 +1,105 @@
+pipeline {
+    agent { label 'x86-4-32-s' }
+
+    options {
+        timestamps ()
+        timeout (time: 1, unit: 'HOURS') // ~ 40min
+        disableConcurrentBuilds(abortPrevious: false)
+    }
+
+    environment {
+        GOGC = '50'
+        GOMEMLIMIT = '120GiB'
+        AIDADB = '/mnt/aida-db-central/aida-db'
+	    TMPDB = '/mnt/tmp-disk'
+    }
+
+     parameters {
+        string(defaultValue: "main", description: 'Can be either branch name or commit hash.', name: 'AidaVersion')
+        string(defaultValue: "main", description: 'Can be either branch name or commit hash.', name: 'CarmenVersion')
+        string(defaultValue: 'main', description: 'Can be either branch name or commit hash.', name: 'ToscaVersion')
+    }
+
+
+
+    stages {
+        stage('Checkout') {
+            steps {
+                script {
+                    currentBuild.description = "Building on ${env.NODE_NAME}"
+                }
+
+                checkout scmGit(
+                    branches: [[name: "${AidaVersion}"]],
+                    userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Aida.git']]
+                )
+
+                sh "git submodule update --init --recursive"
+
+                dir('carmen') {
+                    checkout scmGit(
+                        branches: [[name: "${CarmenVersion}"]],
+                        userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Carmen.git']]
+                    )
+                }
+
+                dir('tosca') {
+                    checkout scmGit(
+                        branches: [[name: "${ToscaVersion}"]],
+                        userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Tosca.git']]
+                    )
+                }
+
+                dir('eth-test-package') {
+                    sh "rm -rf ${env.WORKSPACE}/eth-test-package/tests"
+                    sh "git clone https://github.com/ethereum/tests"
+                }
+            }
+        }
+
+
+        stage('Build') {
+            steps {
+                sh "go mod tidy"
+                sh "make -j aida-vm-sdb"
+            }
+        }
+
+        stage('Start parallel stage execution') {
+            parallel {
+                stage('GethDB+GethVM') {
+                    steps {
+                        sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl geth --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
+                    }
+                }
+                stage('CarmenDB+GethVM') {
+                    steps {
+                        sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl geth --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
+                    }
+                }
+                stage('GethDB+LFVM') {
+                    steps {
+                        sh "./build/aida-vm-sdb ethereum-test --db-impl geth --validate --evm-impl ethereum --vm-impl lfvm --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
+                    }
+                }
+                stage('CarmenDB+LFVM') {
+                    steps {
+                         sh "./build/aida-vm-sdb ethereum-test --db-impl carmen --carmen-schema 5 --validate --evm-impl ethereum --vm-impl lfvm --db-tmp  ${params.tmpDb} ${env.WORKSPACE}/eth-test-package/tests"
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            build job: '/Notifications/slack-notification', parameters: [
+                string(name: 'result', value: "${currentBuild.result}"),
+                string(name: 'name', value: "${currentBuild.fullDisplayName}"),
+                string(name: 'duration', value: "${currentBuild.duration}"),
+                string(name: 'url', value: "${currentBuild.absoluteUrl}"),
+                string(name: 'user', value: "sonic")
+            ]
+        }
+    }
+}

--- a/sonic/geth-state-tests.jenkinsfile
+++ b/sonic/geth-state-tests.jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     environment {
         GOGC = '50'
         GOMEMLIMIT = '120GiB'
-        AIDADB = '/mnt/aida-db-central/aida-db'
 	    TMPDB = '/mnt/tmp-disk'
     }
 
@@ -58,7 +57,6 @@ pipeline {
                 }
             }
         }
-
 
         stage('Build') {
             steps {


### PR DESCRIPTION
This PR adds jenkinsfile which executes `aida geth-tests` upon all combination of `LFVM/GethVM`, `CarmenDB/GethDB`.
It also creates a directory `sonic` for pipelines regarding the client.

Corresponding [pipeline](https://scala.fantom.network/job/Sonic/job/Aida-Geth-State-Tests/) 