### PR TITLE
F17-F19 LFVM validation tests

### DIFF
--- a/release_testing/master.jenkinsfile
+++ b/release_testing/master.jenkinsfile
@@ -38,6 +38,9 @@ pipeline {
         booleanParam(defaultValue: true, description: 'If checked, F11 stage will be executed', name: 'RunF11')
         booleanParam(defaultValue: true, description: 'If checked, F12 stage will be executed', name: 'RunF12')
         booleanParam(defaultValue: true, description: 'If checked, F13 stage will be executed', name: 'RunF13')
+        booleanParam(defaultValue: true, description: 'If checked, F13 stage will be executed', name: 'RunF17')
+        booleanParam(defaultValue: true, description: 'If checked, F13 stage will be executed', name: 'RunF18')
+        booleanParam(defaultValue: true, description: 'If checked, F13 stage will be executed', name: 'RunF19')
         booleanParam(defaultValue: true, description: 'If checked, N01 stage will be executed', name: 'RunN01')
         booleanParam(defaultValue: true, description: 'If checked, N02 stage will be executed', name: 'RunN02')
         booleanParam(defaultValue: false, description: 'If checked, N03 stage will be executed', name: 'RunN03')
@@ -367,6 +370,62 @@ pipeline {
                     steps {
                         build job: '/ReleaseTesting/FunctionalTests/F13', parameters: [
                             string(name: 'LachesisBaseSonicVersion', value: "${LACHESIS_BASE_SONIC_VERSION}")
+                        ]
+                    }
+                }
+
+                stage('F17 Validate LFVM on testnet substate') {
+                    when {
+                        expression {
+                            return params.RunF17;
+                        }
+                    }
+                    steps {
+                        build job: '/Tosca/Validate-LFVM', parameters: [
+                            string(name: 'BlockFrom', value: "${BlockFrom}"),
+                            string(name: 'BlockTo', value: "${BlockTo}"),
+                            string(name: 'AidaVersion', value: "${AIDA_VERSION}"),
+                            string(name: 'ToscaVersion', value: "${TOSCA_VERSION}"),
+                            string(name: 'SubstateDB', value: "/mnt/aida-db-testnet/aida-db"),
+                            string(name: 'ChainID', value: "4002")
+                        ]
+                    }
+                }
+
+                stage('F18 Validate LFVM on mainnet substate') {
+                    when {
+                        expression {
+                            return params.RunF18;
+                        }
+                    }
+                    steps {
+                        build job: '/Tosca/Validate-LFVM', parameters: [
+                            string(name: 'BlockFrom', value: "${BlockFrom}"),
+                            string(name: 'BlockTo', value: "${BlockTo}"),
+                            string(name: 'AidaVersion', value: "${AIDA_VERSION}"),
+                            string(name: 'ToscaVersion', value: "${TOSCA_VERSION}"),
+                            string(name: 'SubstateDB', value: "/mnt/aida-db-mainnet/aida-db"),
+                            string(name: 'ChainID', value: "250")
+                        ]
+                    }
+                }
+
+                stage('F19 Validate LFVM on mainnet substate') {
+                    when {
+                        expression {
+                            return params.RunF19;
+                        }
+                    }
+                    steps {
+                        build job: '/Tosca/Validate-LFVM', parameters: [
+                            string(name: 'BlockFrom', value: "${BlockFrom}"),
+                            string(name: 'BlockTo', value: "${BlockTo}"),
+                            string(name: 'AidaVersion', value: "${AIDA_VERSION}"),
+                            string(name: 'ToscaVersion', value: "${TOSCA_VERSION}"),
+                            string(name: 'SubstateDB', value: "/mnt/aida-ethereum-substate-db/ethereum-substate-db"),
+                            string(name: 'ChainID', value: "1"),
+                            string(name: 'EvmImplementation', value: "ethereum"),
+                            string(name: 'AgentLabel', value: "x86-16-64-s-ethereum-substate")
                         ]
                     }
                 }

--- a/tosca/validate-lfvm.jenkinsfile
+++ b/tosca/validate-lfvm.jenkinsfile
@@ -1,7 +1,7 @@
 // Validate Substate using the Tosca LFVM implementation
 
 pipeline {
-    agent { label 'x86-16-32-s' }
+    agent { label params.AgentLabel }
 
     options {
         timestamps ()
@@ -44,6 +44,16 @@ pipeline {
             defaultValue: "250",
             description: 'Chain ID of corresponding substate DB'
         )
+        string(
+            name: 'EvmImplementation',
+            defaultValue: "opera",
+            description: 'Path to a substate DB'
+        )
+        string(
+            name: "AgentLabel",
+            defaultValue: "x86-16-32-s",
+            description: 'Agent to build this job. Recommended are "x86-16-32-s" for mainnet or testnet substate and "x86-16-64-s-ethereum-substate" for ethereum substate'
+        )
     }
 
     stages {
@@ -77,7 +87,7 @@ pipeline {
         stage('validate') {
             steps {
                 catchError(buildResult: 'FAILURE', stageResult: 'FAILURE', message: 'Test Suite had a failure') {
-                    sh "build/aida-vm --workers 20 --aida-db ${SubstateDB} --chainid ${ChainID} --vm-impl lfvm --validate-tx ${BlockFrom} ${BlockTo}"
+                    sh "build/aida-vm --workers 20 --aida-db ${SubstateDB} --chainid ${ChainID} --evm-impl ${EvmImplementation} --vm-impl lfvm --validate-tx ${BlockFrom} ${BlockTo}"
                 }
             }
         }


### PR DESCRIPTION
Extends Tosca's `validate-lfvm` pipeline with new parameters to allow testing on different substate databases.
Introduces three new stages in release testing master pipeline using Tosca's  newly extended `validate-lfvm`:
1. F17 - opera testnet substateDB
2. F18 - opera mainnet substateDB
3. F19 - ethereum mainnet substateDB