### PR TITLE
lfvm converter fuzzer: Fix jenkins file syntax

### DIFF
--- a/tosca/fuzzing-lfvm-converter.jenkinsfile
+++ b/tosca/fuzzing-lfvm-converter.jenkinsfile
@@ -29,18 +29,18 @@ pipeline {
         )
     }
 
-    stage('clean-cache') {
-        when {
-            expression { return params.CleanCache }
-        }
-        steps {
-            script {
-                sh "rm -rf $GOCACHE"
+    stages {
+        stage('clean-cache') {
+            when {
+                expression { return params.CleanCache }
+            }
+            steps {
+                script {
+                    sh "rm -rf $GOCACHE"
+                }
             }
         }
-    }
 
-    stages {
         stage('checkout') {
             steps {
                 script {


### PR DESCRIPTION
This PR fixes the broken syntax inside the lfvm converter fuzzer which lead to failing test runs. 