### PR TITLE
fixes checkout path for ethereum tests

### DIFF
--- a/sonic/eth-tests.jenkinsfile
+++ b/sonic/eth-tests.jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     userRemoteConfigs: [[url: 'https://github.com/Fantom-foundation/Sonic.git']]
                 )
 
-                dir('tests/test-data') {
+                dir('tests/testdata') {
                     checkout scmGit(
                         branches: [[name: "develop"]],
                         userRemoteConfigs: [[url: 'https://github.com/ethereum/tests.git']]
@@ -32,7 +32,7 @@ pipeline {
             }
         }
 
-        stage('Build') {
+        stage('Tests') {
             steps {
                 sh "go test ./tests -timeout 2h"  
             }


### PR DESCRIPTION
This PR fixes path to` ethereum-tests`

It also renames the stage name for better readibility. 