### PR TITLE
runs only State Tests

### DIFF
--- a/sonic/eth-tests.jenkinsfile
+++ b/sonic/eth-tests.jenkinsfile
@@ -32,9 +32,9 @@ pipeline {
             }
         }
 
-        stage('Tests') {
+        stage('Test State') {
             steps {
-                sh "go test ./tests -timeout 2h"  
+                sh "go test ./tests -timeout 2h -run TestState"  
             }
         }        
     }


### PR DESCRIPTION
This PR updates the script that executes ethereum tests agains Sonic. It makes sure that only State Tests are executed as unrelated tests were added to the same directory. 