### PR TITLE
Prevent race conditions by running tests under the same process

### DIFF
--- a/sonic/race-detection-unit-tests.jenkinsfile
+++ b/sonic/race-detection-unit-tests.jenkinsfile
@@ -44,7 +44,17 @@ pipeline {
 
         stage('go-tests-race-dectection') {
             steps {
-                sh 'go test -race ./... -count 1'
+                script {
+                    // Run unit tests for each subdirectory,
+                    // to prevent resources from modules leaking between tests.
+                    // Ignore hidden, demo, and build directories
+                    def directories = sh(script: 'find . -maxdepth 1 -type d -not -path "./demo" -not -path "./build" -not -path "./.*" -not -path "."', returnStdout: true).trim().split('\n')
+
+                    directories.each { dir ->
+                        echo "Running tests in ${dir}"
+                        sh "go test -race ${dir}/... -count 1"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
There seem to be some odd interactions between tests when running all the subfolders under the same process space. 
For stability of these checks, unit tests will be run by folders. Go will spawn a process for each and run, all the tests found inside. 

https://scala.fantom.network/job/Sonic/job/Unit-test-race-detection/13