### PR TITLE
Revert #206

### DIFF
--- a/sonic/race-detection-unit-tests.jenkinsfile
+++ b/sonic/race-detection-unit-tests.jenkinsfile
@@ -44,17 +44,7 @@ pipeline {
 
         stage('go-tests-race-dectection') {
             steps {
-                script {
-                    // Run unit tests for each subdirectory,
-                    // to prevent resources from modules leaking between tests.
-                    // Ignore hidden, demo, and build directories
-                    def directories = sh(script: 'find . -maxdepth 1 -type d -not -path "./demo" -not -path "./build" -not -path "./.*" -not -path "."', returnStdout: true).trim().split('\n')
-
-                    directories.each { dir ->
-                        echo "Running tests in ${dir}"
-                        sh "go test -race ${dir}/... -count 1"
-                    }
-                }
+                sh 'go test -race ./... -count 1'
             }
         }
     }


### PR DESCRIPTION
This reverts commit 05e450b88b210c35f48eab5f3d1ab1151eb9c18f.

The assumption was that `go test` was running all tests in a single process. This is not the case. Each package generates a different binary. 
The race condition was identified and fixed :https://github.com/Fantom-foundation/Sonic/pull/283