### PR TITLE
Sonic DB Healing: add an option to target devnet

### DIFF
--- a/sonic/db-heal.jenkinsfile
+++ b/sonic/db-heal.jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             }
         }
 
-        stage('Confugure & Build') {
+        stage('Configure & Build') {
             steps {
                 sh 'make clean'
                 sh 'make'


### PR DESCRIPTION
DB healing test has additional network target. This PR changes the preparation steps which check for the chosen network and prepare database accordingly.

This PR also includes minor changes such as removing `--cache` flag to remove HW dependency and have agent configurable.