### PR TITLE
Sonic unit tests: extend unit test timeout

### DIFF
--- a/release_testing/functional_tests/F12.jenkinsfile
+++ b/release_testing/functional_tests/F12.jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 
                 dir('sonic') {
                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                        sh 'go test ./...'
+                        sh 'go test ./... --timeout 30m'
                     }
                 }
             }


### PR DESCRIPTION
This change extend timeout of each test from the default (10 minutes) to 30 minutes.