### PR TITLE
P04: fix check empty content

### DIFF
--- a/utils/rpc-requests.yaml
+++ b/utils/rpc-requests.yaml
@@ -1498,7 +1498,7 @@
   {
     name: "txpool_content_ok",
     body: '{"jsonrpc":"2.0","method":"txpool_content","params":[],"id":1}',
-    result: '"result"\s*:\s*{\s*"pending"\s*:\s*{\s*"[0-9a-fA-Fx\{\}]+"',
+    result: '"result"\s*:\s*{\s*"pending"\s*:\s*{\s*"[0-9a-fA-Fx]*"',
   },
   {
     name: "txpool_content_too_many_args",


### PR DESCRIPTION
 txpool_content request failed when pool doesn't have any transactions. This PR fixes regex and correctly accept empty pool.