### PR TITLE
Remove timeout from RPC test

### DIFF
--- a/sonic/rpc-tests.jenkinsfile
+++ b/sonic/rpc-tests.jenkinsfile
@@ -85,8 +85,6 @@ pipeline {
 
                 stage('Run RPC tests') {
                     steps {
-                        sleep(time:30,unit:"SECONDS")
-
                         sh 'echo "Start RPC tests"'
 
                         dir('rpcTest') {


### PR DESCRIPTION
This PR removes timeout between start of the node and test itself. Test now checks status of the RPC before preforming tests so timeout is not needed anymore.