### PR TITLE
All norma-related machines now use x86-8-64-s

### DIFF
--- a/norma/RunSingleScenario.jenkinsfile
+++ b/norma/RunSingleScenario.jenkinsfile
@@ -2,7 +2,7 @@
 @Library('shared-library') _
 
 pipeline {
-    agent { label 'norma' }
+    agent { label 'worker' }
 
     options {
         timestamps ()


### PR DESCRIPTION
`norma`-tagged images are to be deprecated to streamline maintaining test pipelines. `worker-latest` is to be used instead.