### PR TITLE
Add to P01 two more baseline scenarios

### DIFF
--- a/release_testing/operational_tests/P01.jenkinsfile
+++ b/release_testing/operational_tests/P01.jenkinsfile
@@ -2,7 +2,9 @@
 @Library('shared-library') _
 
 def baselineScenarios = [
-    'scenarios/test/baseline_check.yml'
+    'scenarios/test/baseline_check.yml',
+    'scenarios/test/nodes_net_consistency.yml',
+    'scenarios/test/nodes_start_stop.yml'
 ]
 
 pipeline {
@@ -97,7 +99,6 @@ pipeline {
         stage('Run Target Scenarios in parallel') {
             steps {
                 script {
-                    // currently we only have one baseline scenario, more to be added
                     parallel baselineScenarios.collectEntries { s -> [
                         (s): {
                             build job: '/Norma/RunSingleScenario',


### PR DESCRIPTION
The following 2 scenarios are added as baseline tests in P01:
- https://github.com/Fantom-foundation/Norma/blob/main/scenarios/test/nodes_net_consistency.yml
- https://github.com/Fantom-foundation/Norma/blob/main/scenarios/test/nodes_start_stop.yml

Tested here: https://scala.fantom.network/job/Norma/job/Experimental/job/P01/job/master/36/
