### PR TITLE
Extend VM's memory and update memory cap

### DIFF
--- a/carmen/race-detection.jenkinsfile
+++ b/carmen/race-detection.jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent {label 'x86-8-32-m'}
+    agent {label 'x86-8-64-m'}
 
     options {
         timestamps ()

--- a/carmen/stress-test.jenkinsfile
+++ b/carmen/stress-test.jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent {label 'x86-8-32-m'}
+    agent {label 'x86-8-64-m'}
 
     options {
         timestamps ()
@@ -10,7 +10,7 @@ pipeline {
     environment {
         GORACE = 'halt_on_error=1'
         GOGC = '50'
-        GOMEMLIMIT = '120GiB'
+        GOMEMLIMIT = '60GiB'
     }
 
     parameters {


### PR DESCRIPTION
Both Race detection and Stress unit test were failing due to insufficient memory or too generous memory cap in pipeline. The issue was sadly created with transition to new VM templates. This PR fixes both issues.