### PR TITLE
Increase validate evmzero timeout

### DIFF
--- a/tosca/validate-evmzero.jenkinsfile
+++ b/tosca/validate-evmzero.jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
     options {
         timestamps ()
-        timeout(time: 1, unit: 'DAYS') // expected ~14h
+        timeout(time: 32, unit: 'HOURS') // expected ~26 hours
         disableConcurrentBuilds(abortPrevious: false)
     }
 


### PR DESCRIPTION
The validation of the evmzero takes longer than the interpreter implementations written in Go, as each state has to be converted to C++ and back to Go. 
Several runs have been aborted due to the timeout, this PR is simply increasing the timeout value.